### PR TITLE
Hometask_6 completed

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -38,6 +38,11 @@
             android:theme="@style/AppTheme.NoActionBar.Auth"/>
         <activity
             android:name=".ui.activities.ActivityProfile"
+            android:launchMode="singleTask"
+            android:theme="@style/AppTheme.NoActionBar"/>
+        <activity
+            android:name=".ui.activities.ActivityProfileList"
+            android:launchMode="singleInstance"
             android:theme="@style/AppTheme.NoActionBar"/>
 
         <provider

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -38,7 +38,6 @@
             android:theme="@style/AppTheme.NoActionBar.Auth"/>
         <activity
             android:name=".ui.activities.ActivityProfile"
-            android:launchMode="singleTask"
             android:theme="@style/AppTheme.NoActionBar"/>
         <activity
             android:name=".ui.activities.ActivityProfileList"

--- a/app/src/main/java/com/softdesign/devintensive/data/Model.java
+++ b/app/src/main/java/com/softdesign/devintensive/data/Model.java
@@ -9,6 +9,8 @@ import com.softdesign.devintensive.data.network.dto.UploadImageResult;
 import com.softdesign.devintensive.data.network.dto.User;
 import com.softdesign.devintensive.data.network.params.ParamEdit;
 
+import java.util.List;
+
 import rx.Observable;
 
 /**
@@ -28,4 +30,6 @@ public interface Model {
     Observable<User> userGetProfile(@NonNull String userid);
 
     Observable<User> userGetMe();
+
+    Observable<List<User>> getUserList();
 }

--- a/app/src/main/java/com/softdesign/devintensive/data/ModelImpl.java
+++ b/app/src/main/java/com/softdesign/devintensive/data/ModelImpl.java
@@ -25,6 +25,7 @@ import com.softdesign.devintensive.utils.Utils;
 
 import java.io.File;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import javax.inject.Inject;
@@ -156,6 +157,14 @@ public class ModelImpl implements Model {
                 .map(userBaseResponse -> userBaseResponse.getBody())
                 .doOnNext(user -> PreferenceCache.cacheUser(user))
                 .onErrorReturn(throwable -> PreferenceCache.getUserFromCache())
+                .compose(applySchedulers());
+    }
+
+    @Override
+    public Observable<List<User>> getUserList() {
+        return mSoftdesignApiInterface
+                .userGetList()
+                .map(listBaseResponse -> listBaseResponse.getBody())
                 .compose(applySchedulers());
     }
 

--- a/app/src/main/java/com/softdesign/devintensive/data/network/api/SoftdesignApiClient.java
+++ b/app/src/main/java/com/softdesign/devintensive/data/network/api/SoftdesignApiClient.java
@@ -1,7 +1,6 @@
 package com.softdesign.devintensive.data.network.api;
 
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 
 import com.softdesign.devintensive.data.network.dto.AuthResult;
 import com.softdesign.devintensive.data.network.dto.BaseResponse;
@@ -11,6 +10,7 @@ import com.softdesign.devintensive.data.network.dto.User;
 import com.softdesign.devintensive.data.network.params.ParamAuth;
 import com.softdesign.devintensive.data.network.params.ParamForgotPassword;
 
+import java.util.List;
 import java.util.Map;
 
 import okhttp3.MultipartBody;
@@ -53,4 +53,7 @@ public interface SoftdesignApiClient {
 
     @GET("user/{userId}")
     Observable<BaseResponse<User>> userGet(@NonNull @Path("userId") String userId);
+
+    @GET("user/list?orderBy=rating")
+    Observable<BaseResponse<List<User>>> userGetList();
 }

--- a/app/src/main/java/com/softdesign/devintensive/data/network/dto/BaseResponse.java
+++ b/app/src/main/java/com/softdesign/devintensive/data/network/dto/BaseResponse.java
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 @SuppressWarnings("unused")
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class BaseResponse<T extends BaseValueObject> {
+public class BaseResponse<T> {
     @JsonProperty("success")
     private boolean mSuccess;
 

--- a/app/src/main/java/com/softdesign/devintensive/di/ComponentApp.java
+++ b/app/src/main/java/com/softdesign/devintensive/di/ComponentApp.java
@@ -4,6 +4,7 @@ import com.softdesign.devintensive.data.ModelImpl;
 import com.softdesign.devintensive.presenter.BasePresenter;
 import com.softdesign.devintensive.presenter.PresenterAuth;
 import com.softdesign.devintensive.presenter.PresenterProfile;
+import com.softdesign.devintensive.presenter.PresenterProfileList;
 import com.softdesign.devintensive.presenter.PresenterRestorePassword;
 
 import javax.inject.Singleton;
@@ -25,4 +26,6 @@ public interface ComponentApp {
     void inject(PresenterProfile profilePresenter);
 
     void inject(PresenterRestorePassword presenterRestorePassword);
+
+    void inject(PresenterProfileList presenterProfileList);
 }

--- a/app/src/main/java/com/softdesign/devintensive/di/ComponentProfileList.java
+++ b/app/src/main/java/com/softdesign/devintensive/di/ComponentProfileList.java
@@ -1,6 +1,6 @@
 package com.softdesign.devintensive.di;
 
-import com.softdesign.devintensive.ui.fragments.FragmentProfileList;
+import com.softdesign.devintensive.ui.activities.ActivityProfileList;
 
 import javax.inject.Singleton;
 
@@ -12,5 +12,5 @@ import dagger.Component;
 @Singleton
 @Component(modules = {ModuleProfileList.class})
 public interface ComponentProfileList {
-    void inject(FragmentProfileList fragmentProfileList);
+    void inject(ActivityProfileList activityProfileList);
 }

--- a/app/src/main/java/com/softdesign/devintensive/di/ComponentProfileList.java
+++ b/app/src/main/java/com/softdesign/devintensive/di/ComponentProfileList.java
@@ -1,0 +1,16 @@
+package com.softdesign.devintensive.di;
+
+import com.softdesign.devintensive.ui.fragments.FragmentProfileList;
+
+import javax.inject.Singleton;
+
+import dagger.Component;
+
+/**
+ * Created by skwmium on 14.07.16.
+ */
+@Singleton
+@Component(modules = {ModuleProfileList.class})
+public interface ComponentProfileList {
+    void inject(FragmentProfileList fragmentProfileList);
+}

--- a/app/src/main/java/com/softdesign/devintensive/di/ModuleProfileList.java
+++ b/app/src/main/java/com/softdesign/devintensive/di/ModuleProfileList.java
@@ -1,0 +1,24 @@
+package com.softdesign.devintensive.di;
+
+import com.softdesign.devintensive.presenter.PresenterProfileList;
+import com.softdesign.devintensive.view.ViewProfileList;
+
+import dagger.Module;
+import dagger.Provides;
+
+/**
+ * Created by skwmium on 14.07.16.
+ */
+@Module
+public class ModuleProfileList {
+    private ViewProfileList mView;
+
+    public ModuleProfileList(ViewProfileList view) {
+        mView = view;
+    }
+
+    @Provides
+    public PresenterProfileList providePresenter() {
+        return new PresenterProfileList(mView);
+    }
+}

--- a/app/src/main/java/com/softdesign/devintensive/presenter/PresenterProfile.java
+++ b/app/src/main/java/com/softdesign/devintensive/presenter/PresenterProfile.java
@@ -16,7 +16,6 @@ import com.softdesign.devintensive.presenter.mappers.MapperParamEdit;
 import com.softdesign.devintensive.presenter.mappers.MapperUser;
 import com.softdesign.devintensive.ui.viewmodel.ProfileViewModel;
 import com.softdesign.devintensive.utils.Const;
-import com.softdesign.devintensive.utils.L;
 import com.softdesign.devintensive.utils.Utils;
 import com.softdesign.devintensive.view.ViewProfile;
 
@@ -73,7 +72,7 @@ public class PresenterProfile extends BasePresenter {
 
     public void onCreate(Bundle savedInstanceState) {
         if (savedInstanceState != null) {
-            mProfileViewModel = (ProfileViewModel) savedInstanceState.getSerializable(Const.KEY_PROFILE);
+            mProfileViewModel = savedInstanceState.getParcelable(Const.KEY_PROFILE);
         }
         if (mProfileViewModel == null) {
             loadProfile();
@@ -83,7 +82,7 @@ public class PresenterProfile extends BasePresenter {
     }
 
     public void onSaveInstanceState(Bundle outState) {
-        outState.putSerializable(Const.KEY_PROFILE, mProfileViewModel);
+        outState.putParcelable(Const.KEY_PROFILE, mProfileViewModel);
     }
 
     public void onActivityResult(int requestCode, int resultCode, Intent data) {

--- a/app/src/main/java/com/softdesign/devintensive/presenter/PresenterProfile.java
+++ b/app/src/main/java/com/softdesign/devintensive/presenter/PresenterProfile.java
@@ -75,6 +75,9 @@ public class PresenterProfile extends BasePresenter {
             mProfileViewModel = savedInstanceState.getParcelable(Const.KEY_PROFILE);
         }
         if (mProfileViewModel == null) {
+            mProfileViewModel = mView.getIntent().getParcelableExtra(Const.KEY_PROFILE);
+        }
+        if (mProfileViewModel == null) {
             loadProfile();
         } else {
             mView.setProfileViewModel(mProfileViewModel);

--- a/app/src/main/java/com/softdesign/devintensive/presenter/PresenterProfileList.java
+++ b/app/src/main/java/com/softdesign/devintensive/presenter/PresenterProfileList.java
@@ -1,0 +1,85 @@
+package com.softdesign.devintensive.presenter;
+
+import android.os.Bundle;
+import android.os.Parcelable;
+import android.support.annotation.Nullable;
+
+import com.softdesign.devintensive.R;
+import com.softdesign.devintensive.common.App;
+import com.softdesign.devintensive.data.Model;
+import com.softdesign.devintensive.presenter.mappers.MapperUserList;
+import com.softdesign.devintensive.ui.viewmodel.ProfileViewModel;
+import com.softdesign.devintensive.utils.Const;
+import com.softdesign.devintensive.view.ViewProfileList;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.inject.Inject;
+
+import rx.Subscriber;
+import rx.Subscription;
+
+/**
+ * Created by skwmium on 14.07.16.
+ */
+public class PresenterProfileList extends BasePresenter {
+    @Inject
+    Model mModel;
+
+    @Inject
+    MapperUserList mMapperUserList;
+
+    private ViewProfileList mView;
+    private List<ProfileViewModel> mProfileList = new ArrayList<>();
+
+    @Inject
+    public PresenterProfileList() {
+    }
+
+    public PresenterProfileList(ViewProfileList view) {
+        App.getAppComponent().inject(this);
+        mView = view;
+    }
+
+    public void onViewCreated(@Nullable Bundle savedInstanceState) {
+        if (savedInstanceState != null) {
+            ArrayList<ProfileViewModel> savedList = savedInstanceState.getParcelableArrayList(Const.KEY_PROFILE_LIST);
+            if (savedList != null) {
+                mProfileList = savedList;
+                mView.showProfileList(mProfileList);
+                return;
+            }
+        }
+        loadProfileList();
+    }
+
+    public void onSaveInstanceState(Bundle outState) {
+        outState.putParcelableArrayList(Const.KEY_PROFILE_LIST, (ArrayList<? extends Parcelable>) mProfileList);
+    }
+
+    private void loadProfileList() {
+        mView.showProgress();
+        Subscription subscription = mModel.getUserList()
+                .map(mMapperUserList)
+                .subscribe(new Subscriber<List<ProfileViewModel>>() {
+                    @Override
+                    public void onCompleted() {
+                        mView.hideProgress();
+                    }
+
+                    @Override
+                    public void onError(Throwable e) {
+                        mView.showMessage(R.string.error_loading_data);
+                        mView.hideProgress();
+                    }
+
+                    @Override
+                    public void onNext(List<ProfileViewModel> profileViewModels) {
+                        mProfileList = profileViewModels;
+                        mView.showProfileList(profileViewModels);
+                    }
+                });
+        addSubscription(subscription);
+    }
+}

--- a/app/src/main/java/com/softdesign/devintensive/presenter/PresenterProfileList.java
+++ b/app/src/main/java/com/softdesign/devintensive/presenter/PresenterProfileList.java
@@ -2,7 +2,6 @@ package com.softdesign.devintensive.presenter;
 
 import android.os.Bundle;
 import android.os.Parcelable;
-import android.support.annotation.Nullable;
 
 import com.softdesign.devintensive.R;
 import com.softdesign.devintensive.common.App;
@@ -42,7 +41,7 @@ public class PresenterProfileList extends BasePresenter {
         mView = view;
     }
 
-    public void onViewCreated(@Nullable Bundle savedInstanceState) {
+    public void onCreate(Bundle savedInstanceState) {
         if (savedInstanceState != null) {
             ArrayList<ProfileViewModel> savedList = savedInstanceState.getParcelableArrayList(Const.KEY_PROFILE_LIST);
             if (savedList != null) {

--- a/app/src/main/java/com/softdesign/devintensive/presenter/PresenterProfileList.java
+++ b/app/src/main/java/com/softdesign/devintensive/presenter/PresenterProfileList.java
@@ -2,6 +2,8 @@ package com.softdesign.devintensive.presenter;
 
 import android.os.Bundle;
 import android.os.Parcelable;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import com.softdesign.devintensive.R;
 import com.softdesign.devintensive.common.App;
@@ -9,6 +11,8 @@ import com.softdesign.devintensive.data.Model;
 import com.softdesign.devintensive.presenter.mappers.MapperUserList;
 import com.softdesign.devintensive.ui.viewmodel.ProfileViewModel;
 import com.softdesign.devintensive.utils.Const;
+import com.softdesign.devintensive.utils.L;
+import com.softdesign.devintensive.utils.Utils;
 import com.softdesign.devintensive.view.ViewProfileList;
 
 import java.util.ArrayList;
@@ -16,8 +20,11 @@ import java.util.List;
 
 import javax.inject.Inject;
 
+import rx.Observable;
 import rx.Subscriber;
 import rx.Subscription;
+import rx.android.schedulers.AndroidSchedulers;
+import rx.schedulers.Schedulers;
 
 /**
  * Created by skwmium on 14.07.16.
@@ -28,6 +35,9 @@ public class PresenterProfileList extends BasePresenter {
 
     @Inject
     MapperUserList mMapperUserList;
+
+    @Nullable
+    private Subscription mPrevSubscriptionFilter;
 
     private ViewProfileList mView;
     private List<ProfileViewModel> mProfileList = new ArrayList<>();
@@ -55,6 +65,28 @@ public class PresenterProfileList extends BasePresenter {
 
     public void onSaveInstanceState(Bundle outState) {
         outState.putParcelableArrayList(Const.KEY_PROFILE_LIST, (ArrayList<? extends Parcelable>) mProfileList);
+    }
+
+    public void filterProfiles(@NonNull String query) {
+        L.e("filter query ", query);
+        if (mPrevSubscriptionFilter != null && mPrevSubscriptionFilter.isUnsubscribed()) {
+            mCompositeSubscription.remove(mPrevSubscriptionFilter);
+            mPrevSubscriptionFilter.unsubscribe();
+        }
+        mPrevSubscriptionFilter = Observable.from(mProfileList)
+                .filter(viewModel -> {
+                    String model = viewModel.getName();
+                    String pattern = query.toLowerCase();
+                    //noinspection SimplifiableIfStatement
+                    if (Utils.isNullOrEmpty(model) && !pattern.isEmpty())
+                        return false;
+                    return model.toLowerCase().startsWith(query);
+                })
+                .toList()
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(profileViewModels -> mView.showProfileList(profileViewModels));
+        mCompositeSubscription.add(mPrevSubscriptionFilter);
     }
 
     private void loadProfileList() {

--- a/app/src/main/java/com/softdesign/devintensive/presenter/mappers/MapperUser.java
+++ b/app/src/main/java/com/softdesign/devintensive/presenter/mappers/MapperUser.java
@@ -1,10 +1,13 @@
 package com.softdesign.devintensive.presenter.mappers;
 
+import android.support.annotation.Nullable;
+
 import com.softdesign.devintensive.data.network.dto.Contacts;
 import com.softdesign.devintensive.data.network.dto.ProfileValues;
 import com.softdesign.devintensive.data.network.dto.PublicInfo;
 import com.softdesign.devintensive.data.network.dto.Repositories;
 import com.softdesign.devintensive.data.network.dto.User;
+import com.softdesign.devintensive.data.storage.LocalUser;
 import com.softdesign.devintensive.ui.viewmodel.ProfileViewModel;
 
 import javax.inject.Inject;
@@ -16,9 +19,16 @@ import rx.functions.Func1;
  * Created by skwmium on 08.07.16.
  */
 public class MapperUser implements Func1<User, ProfileViewModel> {
+    @Nullable
+    private String mLocalUserid;
 
     @Inject
     public MapperUser() {
+        mLocalUserid = LocalUser.getInst().getUserId();
+    }
+
+    private boolean isLocalUser(String id) {
+        return mLocalUserid != null && id != null && mLocalUserid.equals(id);
     }
 
     @Override
@@ -26,6 +36,7 @@ public class MapperUser implements Func1<User, ProfileViewModel> {
         return Observable.just(userDto)
                 .map(user -> {
                     ProfileViewModel profileViewModel = new ProfileViewModel();
+                    profileViewModel.setCanBeEditable(isLocalUser(user.getId()));
                     profileViewModel.setName(user.getFirstName() + " " + user.getSecondName());
 
                     ProfileValues profileValues = user.getProfileValues();

--- a/app/src/main/java/com/softdesign/devintensive/presenter/mappers/MapperUserList.java
+++ b/app/src/main/java/com/softdesign/devintensive/presenter/mappers/MapperUserList.java
@@ -1,0 +1,32 @@
+package com.softdesign.devintensive.presenter.mappers;
+
+import com.softdesign.devintensive.data.network.dto.User;
+import com.softdesign.devintensive.ui.viewmodel.ProfileViewModel;
+
+import java.util.List;
+
+import javax.inject.Inject;
+
+import rx.Observable;
+import rx.functions.Func1;
+
+/**
+ * Created by skwmium on 14.07.16.
+ */
+public class MapperUserList implements Func1<List<User>, List<ProfileViewModel>> {
+    @Inject
+    MapperUser mapperUser;
+
+    @Inject
+    public MapperUserList() {
+    }
+
+    @Override
+    public List<ProfileViewModel> call(List<User> users) {
+        return Observable.from(users)
+                .map(mapperUser)
+                .toList()
+                .toBlocking()
+                .first();
+    }
+}

--- a/app/src/main/java/com/softdesign/devintensive/ui/activities/ActivityProfile.java
+++ b/app/src/main/java/com/softdesign/devintensive/ui/activities/ActivityProfile.java
@@ -7,20 +7,13 @@ import android.graphics.Color;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.support.annotation.StringRes;
 import android.support.design.widget.CollapsingToolbarLayout;
 import android.support.design.widget.FloatingActionButton;
 import android.support.design.widget.NavigationView;
-import android.support.v4.view.GravityCompat;
-import android.support.v4.widget.DrawerLayout;
-import android.support.v7.app.ActionBarDrawerToggle;
-import android.support.v7.widget.Toolbar;
-import android.view.MenuItem;
 import android.view.View;
 
 import com.softdesign.devintensive.R;
 import com.softdesign.devintensive.databinding.AppBarProfileBinding;
-import com.softdesign.devintensive.databinding.NavHeaderMainBinding;
 import com.softdesign.devintensive.di.DaggerComponentProfile;
 import com.softdesign.devintensive.di.ModuleViewProfile;
 import com.softdesign.devintensive.presenter.BasePresenter;
@@ -43,15 +36,6 @@ public class ActivityProfile extends BaseActivity implements ViewProfile, Naviga
         context.startActivity(intent);
     }
 
-    @BindView(R.id.toolbar)
-    Toolbar toolbar;
-
-    @BindView(R.id.drawer_layout)
-    DrawerLayout drawerLayout;
-
-    @BindView(R.id.nav_view)
-    NavigationView navigationView;
-
     @BindView(R.id.fab_edit_profile)
     FloatingActionButton floatingActionEdit;
 
@@ -65,7 +49,7 @@ public class ActivityProfile extends BaseActivity implements ViewProfile, Naviga
     PresenterProfile mPresenter;
 
     private AppBarProfileBinding mProfileBinding;
-    private NavHeaderMainBinding mNavHeaderMainBinding;
+//    private NavHeaderMainBinding mNavHeaderMainBinding;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -83,10 +67,9 @@ public class ActivityProfile extends BaseActivity implements ViewProfile, Naviga
     }
 
     private void init() {
-        initToolbar();
         mProfileBinding = DataBindingUtil.bind(viewProfileBinding);
-        mNavHeaderMainBinding = DataBindingUtil.bind(navigationView.getHeaderView(0));
-        mNavHeaderMainBinding.imageAvatar.setOnClickListener(this);
+//        mNavHeaderMainBinding = DataBindingUtil.bind(navigationView.getHeaderView(0));
+//        mNavHeaderMainBinding.imageAvatar.setOnClickListener(this);
 
         mProfileBinding.contentProfile.imageActionPhone.setOnClickListener(this);
         mProfileBinding.contentProfile.imageActionEmail.setOnClickListener(this);
@@ -121,12 +104,6 @@ public class ActivityProfile extends BaseActivity implements ViewProfile, Naviga
     }
 
     @Override
-    public boolean onNavigationItemSelected(MenuItem item) {
-        if (drawerLayout != null) drawerLayout.closeDrawer(GravityCompat.START);
-        return false;
-    }
-
-    @Override
     public void onClick(View view) {
         switch (view.getId()) {
             case R.id.fab_edit_profile:
@@ -154,34 +131,6 @@ public class ActivityProfile extends BaseActivity implements ViewProfile, Naviga
     }
 
     @Override
-    public void onBackPressed() {
-        if (drawerLayout != null && drawerLayout.isDrawerOpen(GravityCompat.START)) {
-            drawerLayout.closeDrawer(GravityCompat.START);
-        } else {
-            super.onBackPressed();
-        }
-    }
-
-    private void initToolbar() {
-        setSupportActionBar(toolbar);
-        navigationView.setNavigationItemSelectedListener(this);
-        ActionBarDrawerToggle toggle = new ActionBarDrawerToggle(this, drawerLayout, toolbar, 0, 0);
-        //noinspection deprecation
-        drawerLayout.setDrawerListener(toggle);
-        toggle.syncState();
-    }
-
-    @Override
-    public void showMessage(@StringRes int res) {
-        showSnackbar(res);
-    }
-
-    @Override
-    public Context getContext() {
-        return this;
-    }
-
-    @Override
     public ActivityProfile getActivity() {
         return this;
     }
@@ -194,7 +143,7 @@ public class ActivityProfile extends BaseActivity implements ViewProfile, Naviga
     @Override
     public void setProfileViewModel(ProfileViewModel profileViewModel) {
         mProfileBinding.setProfile(profileViewModel);
-        mNavHeaderMainBinding.setProfile(profileViewModel);
+//        mNavHeaderMainBinding.setProfile(profileViewModel);
     }
 
     @Override

--- a/app/src/main/java/com/softdesign/devintensive/ui/activities/ActivityProfile.java
+++ b/app/src/main/java/com/softdesign/devintensive/ui/activities/ActivityProfile.java
@@ -20,6 +20,7 @@ import com.softdesign.devintensive.presenter.BasePresenter;
 import com.softdesign.devintensive.presenter.PresenterProfile;
 import com.softdesign.devintensive.ui.dialogs.DialogChooseProfilePhoto;
 import com.softdesign.devintensive.ui.viewmodel.ProfileViewModel;
+import com.softdesign.devintensive.utils.Const;
 import com.softdesign.devintensive.view.ViewProfile;
 
 import javax.inject.Inject;
@@ -32,7 +33,12 @@ import static com.softdesign.devintensive.ui.dialogs.DialogChooseProfilePhoto.On
 public class ActivityProfile extends BaseActivity implements ViewProfile, NavigationView.OnNavigationItemSelectedListener
         , View.OnClickListener {
     public static void start(@NonNull Context context) {
+        start(context, null);
+    }
+
+    public static void start(@NonNull Context context, @Nullable ProfileViewModel viewModel) {
         Intent intent = new Intent(context, ActivityProfile.class);
+        intent.putExtra(Const.KEY_PROFILE, viewModel);
         context.startActivity(intent);
     }
 

--- a/app/src/main/java/com/softdesign/devintensive/ui/activities/ActivityProfileList.java
+++ b/app/src/main/java/com/softdesign/devintensive/ui/activities/ActivityProfileList.java
@@ -5,6 +5,7 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.v7.app.ActionBar;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 
@@ -14,6 +15,8 @@ import com.softdesign.devintensive.di.ModuleProfileList;
 import com.softdesign.devintensive.presenter.BasePresenter;
 import com.softdesign.devintensive.presenter.PresenterProfileList;
 import com.softdesign.devintensive.ui.adapters.AdapterProfileList;
+import com.softdesign.devintensive.ui.adapters.OnItemCLickListener;
+import com.softdesign.devintensive.ui.viewmodel.BaseViewModel;
 import com.softdesign.devintensive.ui.viewmodel.ProfileViewModel;
 import com.softdesign.devintensive.view.ViewProfileList;
 
@@ -26,7 +29,7 @@ import butterknife.BindView;
 /**
  * Created by skwmium on 15.07.16.
  */
-public class ActivityProfileList extends BaseActivity implements ViewProfileList {
+public class ActivityProfileList extends BaseActivity implements ViewProfileList, OnItemCLickListener {
     public static void start(@NonNull Context context) {
         Intent intent = new Intent(context, ActivityProfileList.class);
         context.startActivity(intent);
@@ -55,8 +58,13 @@ public class ActivityProfileList extends BaseActivity implements ViewProfileList
     }
 
     private void init() {
-        recyclerView.setLayoutManager(new LinearLayoutManager(getContext()));
+        ActionBar actionBar = getSupportActionBar();
+        if (actionBar != null) {
+            actionBar.setTitle(R.string.nav_item_contacts);
+        }
         mAdapterProfileList = new AdapterProfileList();
+        mAdapterProfileList.setItemCLickListener(this);
+        recyclerView.setLayoutManager(new LinearLayoutManager(getContext()));
         recyclerView.setAdapter(mAdapterProfileList);
     }
 
@@ -75,5 +83,11 @@ public class ActivityProfileList extends BaseActivity implements ViewProfileList
     @Override
     public void showProfileList(List<ProfileViewModel> profileViewModels) {
         mAdapterProfileList.setItems(profileViewModels);
+    }
+
+    @Override
+    public void onItemClick(BaseViewModel viewModel) {
+        ProfileViewModel profileViewModel = (ProfileViewModel) viewModel;
+        ActivityProfile.start(this, profileViewModel);
     }
 }

--- a/app/src/main/java/com/softdesign/devintensive/ui/activities/ActivityProfileList.java
+++ b/app/src/main/java/com/softdesign/devintensive/ui/activities/ActivityProfileList.java
@@ -5,9 +5,13 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.v4.view.MenuItemCompat;
 import android.support.v7.app.ActionBar;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
+import android.support.v7.widget.SearchView;
+import android.view.Menu;
+import android.view.MenuItem;
 
 import com.softdesign.devintensive.R;
 import com.softdesign.devintensive.di.DaggerComponentProfileList;
@@ -29,7 +33,8 @@ import butterknife.BindView;
 /**
  * Created by skwmium on 15.07.16.
  */
-public class ActivityProfileList extends BaseActivity implements ViewProfileList, OnItemCLickListener {
+public class ActivityProfileList extends BaseActivity implements ViewProfileList, OnItemCLickListener,
+        SearchView.OnQueryTextListener {
     public static void start(@NonNull Context context) {
         Intent intent = new Intent(context, ActivityProfileList.class);
         context.startActivity(intent);
@@ -62,6 +67,10 @@ public class ActivityProfileList extends BaseActivity implements ViewProfileList
         if (actionBar != null) {
             actionBar.setTitle(R.string.nav_item_contacts);
         }
+        if (toolbar != null) {
+            toolbar.setOnClickListener(view -> recyclerView.scrollToPosition(0));
+        }
+
         mAdapterProfileList = new AdapterProfileList();
         mAdapterProfileList.setItemCLickListener(this);
         recyclerView.setLayoutManager(new LinearLayoutManager(getContext()));
@@ -72,6 +81,16 @@ public class ActivityProfileList extends BaseActivity implements ViewProfileList
     public void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
         mPresenter.onSaveInstanceState(outState);
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        getMenuInflater().inflate(R.menu.toolbar_profile_list, menu);
+
+        MenuItem searchItem = menu.findItem(R.id.nav_search);
+        SearchView searchView = (SearchView) MenuItemCompat.getActionView(searchItem);
+        searchView.setOnQueryTextListener(this);
+        return true;
     }
 
     @Nullable
@@ -89,5 +108,16 @@ public class ActivityProfileList extends BaseActivity implements ViewProfileList
     public void onItemClick(BaseViewModel viewModel) {
         ProfileViewModel profileViewModel = (ProfileViewModel) viewModel;
         ActivityProfile.start(this, profileViewModel);
+    }
+
+    @Override
+    public boolean onQueryTextSubmit(String query) {
+        return false;
+    }
+
+    @Override
+    public boolean onQueryTextChange(String newText) {
+        mPresenter.filterProfiles(newText);
+        return false;
     }
 }

--- a/app/src/main/java/com/softdesign/devintensive/ui/activities/ActivityProfileList.java
+++ b/app/src/main/java/com/softdesign/devintensive/ui/activities/ActivityProfileList.java
@@ -1,12 +1,12 @@
-package com.softdesign.devintensive.ui.fragments;
+package com.softdesign.devintensive.ui.activities;
 
+import android.content.Context;
+import android.content.Intent;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
-import android.view.LayoutInflater;
-import android.view.View;
-import android.view.ViewGroup;
 
 import com.softdesign.devintensive.R;
 import com.softdesign.devintensive.di.DaggerComponentProfileList;
@@ -24,9 +24,14 @@ import javax.inject.Inject;
 import butterknife.BindView;
 
 /**
- * Created by skwmium on 14.07.16.
+ * Created by skwmium on 15.07.16.
  */
-public class FragmentProfileList extends BaseFragment implements ViewProfileList {
+public class ActivityProfileList extends BaseActivity implements ViewProfileList {
+    public static void start(@NonNull Context context) {
+        Intent intent = new Intent(context, ActivityProfileList.class);
+        context.startActivity(intent);
+    }
+
     @BindView(R.id.recycler)
     RecyclerView recyclerView;
 
@@ -37,28 +42,22 @@ public class FragmentProfileList extends BaseFragment implements ViewProfileList
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_profile_list);
 
         DaggerComponentProfileList
                 .builder()
                 .moduleProfileList(new ModuleProfileList(this))
                 .build()
                 .inject(this);
+
+        init();
+        mPresenter.onCreate(savedInstanceState);
     }
 
-    @Nullable
-    @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-        return inflater.inflate(R.layout.fragment_profile_list, container, false);
-    }
-
-    @Override
-    public void onViewCreated(View view, Bundle savedInstanceState) {
-        super.onViewCreated(view, savedInstanceState);
+    private void init() {
         recyclerView.setLayoutManager(new LinearLayoutManager(getContext()));
         mAdapterProfileList = new AdapterProfileList();
         recyclerView.setAdapter(mAdapterProfileList);
-
-        mPresenter.onViewCreated(savedInstanceState);
     }
 
     @Override

--- a/app/src/main/java/com/softdesign/devintensive/ui/activities/BaseActivity.java
+++ b/app/src/main/java/com/softdesign/devintensive/ui/activities/BaseActivity.java
@@ -1,6 +1,7 @@
 package com.softdesign.devintensive.ui.activities;
 
 import android.app.ProgressDialog;
+import android.content.Context;
 import android.graphics.Color;
 import android.graphics.drawable.ColorDrawable;
 import android.os.Bundle;
@@ -8,28 +9,48 @@ import android.support.annotation.IdRes;
 import android.support.annotation.LayoutRes;
 import android.support.annotation.Nullable;
 import android.support.annotation.StringRes;
+import android.support.design.widget.NavigationView;
 import android.support.design.widget.Snackbar;
+import android.support.v4.view.GravityCompat;
+import android.support.v4.widget.DrawerLayout;
+import android.support.v7.app.ActionBarDrawerToggle;
 import android.support.v7.app.AppCompatActivity;
+import android.support.v7.widget.Toolbar;
+import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 
 import com.softdesign.devintensive.R;
-import com.softdesign.devintensive.ui.view.InflaterFactory;
 import com.softdesign.devintensive.presenter.BasePresenter;
+import com.softdesign.devintensive.ui.view.InflaterFactory;
+import com.softdesign.devintensive.utils.L;
 
+import butterknife.BindView;
 import butterknife.ButterKnife;
 
 /**
  * Created by skwmium on 22.06.16.
  */
-public abstract class BaseActivity extends AppCompatActivity {
+@SuppressWarnings("unused")
+public abstract class BaseActivity extends AppCompatActivity implements com.softdesign.devintensive.view.View,
+        NavigationView.OnNavigationItemSelectedListener {
+    @Nullable
     private ProgressDialog mProgressDialog;
 
-    public <T extends View> T $(@IdRes int id) {
-        //noinspection unchecked
-        return (T) findViewById(id);
-    }
+    @Nullable
+    @BindView(R.id.toolbar)
+    Toolbar toolbar;
 
+    @Nullable
+    @BindView(R.id.drawer_layout)
+    DrawerLayout drawerLayout;
+
+    @Nullable
+    @BindView(R.id.nav_view)
+    NavigationView navigationView;
+
+
+    // ---------- ACTIVITY LOGIC ----------
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         getLayoutInflater().setFactory(new InflaterFactory(this));
@@ -48,12 +69,14 @@ public abstract class BaseActivity extends AppCompatActivity {
     public void setContentView(@LayoutRes int layoutResID) {
         super.setContentView(layoutResID);
         ButterKnife.bind(this);
+        initUi();
     }
 
     @Override
     public void setContentView(View view) {
         super.setContentView(view);
         ButterKnife.bind(this);
+        initUi();
     }
 
     @Nullable
@@ -63,6 +86,18 @@ public abstract class BaseActivity extends AppCompatActivity {
         return rootGroup.getChildAt(0);
     }
 
+    @Override
+    public void onBackPressed() {
+        if (drawerLayout != null && drawerLayout.isDrawerOpen(GravityCompat.START)) {
+            drawerLayout.closeDrawer(GravityCompat.START);
+        } else {
+            super.onBackPressed();
+        }
+    }
+
+
+    // ---------- PROGRESS DIALOG ----------
+    @Override
     public void showProgress() {
         if (mProgressDialog == null) {
             mProgressDialog = new ProgressDialog(this, R.style.activity_base_progress_dialog);
@@ -73,11 +108,19 @@ public abstract class BaseActivity extends AppCompatActivity {
         mProgressDialog.setContentView(R.layout.dialog_progress_activity);
     }
 
+    @Override
     public void hideProgress() {
         if (mProgressDialog == null || !mProgressDialog.isShowing()) {
             return;
         }
         mProgressDialog.dismiss();
+    }
+
+
+    // ---------- MESSAGES ----------
+    @Override
+    public void showMessage(@StringRes int res) {
+        showSnackbar(res);
     }
 
     public void showSnackbar(@StringRes int res) {
@@ -91,12 +134,54 @@ public abstract class BaseActivity extends AppCompatActivity {
         Snackbar.make(rootView, s, Snackbar.LENGTH_SHORT).show();
     }
 
-    @Nullable
-    protected abstract BasePresenter getPresenter();
+
+    // ---------- OTHER UI LOGIC ----------
+    @Override
+    public boolean onNavigationItemSelected(MenuItem item) {
+        if (drawerLayout != null) drawerLayout.closeDrawer(GravityCompat.START);
+        switch (item.getItemId()) {
+            case R.id.nav_item_contacts:
+                ActivityProfileList.start(this);
+                return true;
+            case R.id.nav_item_profile:
+                ActivityProfile.start(this);
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private void initUi() {
+        if (navigationView != null) {
+            navigationView.setNavigationItemSelectedListener(this);
+        }
+        if (toolbar != null && drawerLayout != null) {
+            setSupportActionBar(toolbar);
+            ActionBarDrawerToggle toggle = new ActionBarDrawerToggle(this, drawerLayout, toolbar, 0, 0);
+            //noinspection deprecation
+            drawerLayout.setDrawerListener(toggle);
+            toggle.syncState();
+        }
+    }
+
+
+    // ---------- UTIL ----------
+    public <T extends View> T $(@IdRes int id) {
+        //noinspection unchecked
+        return (T) findViewById(id);
+    }
 
     @Nullable
     public <T extends BaseActivity> T as(Class<T> clazz) {
         //noinspection unchecked
         return (T) this;
     }
+
+    @Override
+    public Context getContext() {
+        return getApplicationContext();
+    }
+
+    @Nullable
+    protected abstract BasePresenter getPresenter();
 }

--- a/app/src/main/java/com/softdesign/devintensive/ui/adapters/AdapterProfileList.java
+++ b/app/src/main/java/com/softdesign/devintensive/ui/adapters/AdapterProfileList.java
@@ -1,0 +1,64 @@
+package com.softdesign.devintensive.ui.adapters;
+
+import android.databinding.DataBindingUtil;
+import android.support.annotation.NonNull;
+import android.support.v7.widget.RecyclerView;
+import android.view.LayoutInflater;
+import android.view.ViewGroup;
+
+import com.softdesign.devintensive.R;
+import com.softdesign.devintensive.databinding.ItemListProfileBinding;
+import com.softdesign.devintensive.ui.viewmodel.ProfileViewModel;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Created by skwmium on 14.07.16.
+ */
+public class AdapterProfileList extends RecyclerView.Adapter<AdapterProfileList.ViewHolder> {
+    @NonNull
+    private List<ProfileViewModel> mProfileViewModels = new ArrayList<>();
+
+    public void setItems(List<ProfileViewModel> profileViewModels) {
+        if (profileViewModels == null) {
+            mProfileViewModels.clear();
+        } else {
+            mProfileViewModels = profileViewModels;
+        }
+        notifyDataSetChanged();
+    }
+
+    @Override
+    public ViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+        ItemListProfileBinding profileBinding = DataBindingUtil.inflate(
+                LayoutInflater.from(parent.getContext()),
+                R.layout.item_list_profile,
+                parent, false);
+        return new ViewHolder(profileBinding);
+    }
+
+    @Override
+    public void onBindViewHolder(ViewHolder holder, int position) {
+        holder.getProfileBinding().setProfile(mProfileViewModels.get(position));
+    }
+
+    @Override
+    public int getItemCount() {
+        return mProfileViewModels.size();
+    }
+
+    // ---------- HOLDER ----------
+    public static class ViewHolder extends RecyclerView.ViewHolder {
+        private ItemListProfileBinding mProfileBinding;
+
+        public ViewHolder(ItemListProfileBinding profileBinding) {
+            super(profileBinding.getRoot());
+            mProfileBinding = profileBinding;
+        }
+
+        public ItemListProfileBinding getProfileBinding() {
+            return mProfileBinding;
+        }
+    }
+}

--- a/app/src/main/java/com/softdesign/devintensive/ui/adapters/AdapterProfileList.java
+++ b/app/src/main/java/com/softdesign/devintensive/ui/adapters/AdapterProfileList.java
@@ -2,6 +2,7 @@ package com.softdesign.devintensive.ui.adapters;
 
 import android.databinding.DataBindingUtil;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.ViewGroup;
@@ -19,6 +20,12 @@ import java.util.List;
 public class AdapterProfileList extends RecyclerView.Adapter<AdapterProfileList.ViewHolder> {
     @NonNull
     private List<ProfileViewModel> mProfileViewModels = new ArrayList<>();
+    @Nullable
+    private OnItemCLickListener mItemCLickListener;
+
+    public void setItemCLickListener(@Nullable OnItemCLickListener itemCLickListener) {
+        mItemCLickListener = itemCLickListener;
+    }
 
     public void setItems(List<ProfileViewModel> profileViewModels) {
         if (profileViewModels == null) {
@@ -29,18 +36,22 @@ public class AdapterProfileList extends RecyclerView.Adapter<AdapterProfileList.
         notifyDataSetChanged();
     }
 
+    private ProfileViewModel getItem(int position) {
+        return mProfileViewModels.get(position);
+    }
+
     @Override
     public ViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
         ItemListProfileBinding profileBinding = DataBindingUtil.inflate(
                 LayoutInflater.from(parent.getContext()),
                 R.layout.item_list_profile,
                 parent, false);
-        return new ViewHolder(profileBinding);
+        return new ViewHolder(profileBinding, mItemCLickListener);
     }
 
     @Override
     public void onBindViewHolder(ViewHolder holder, int position) {
-        holder.getProfileBinding().setProfile(mProfileViewModels.get(position));
+        holder.getProfileBinding().setProfile(getItem(position));
     }
 
     @Override
@@ -52,9 +63,14 @@ public class AdapterProfileList extends RecyclerView.Adapter<AdapterProfileList.
     public static class ViewHolder extends RecyclerView.ViewHolder {
         private ItemListProfileBinding mProfileBinding;
 
-        public ViewHolder(ItemListProfileBinding profileBinding) {
+        public ViewHolder(ItemListProfileBinding profileBinding, OnItemCLickListener listener) {
             super(profileBinding.getRoot());
             mProfileBinding = profileBinding;
+            mProfileBinding.buttonOpen.setOnClickListener(view -> {
+                if (listener != null) {
+                    listener.onItemClick(mProfileBinding.getProfile());
+                }
+            });
         }
 
         public ItemListProfileBinding getProfileBinding() {

--- a/app/src/main/java/com/softdesign/devintensive/ui/adapters/OnItemCLickListener.java
+++ b/app/src/main/java/com/softdesign/devintensive/ui/adapters/OnItemCLickListener.java
@@ -1,0 +1,10 @@
+package com.softdesign.devintensive.ui.adapters;
+
+import com.softdesign.devintensive.ui.viewmodel.BaseViewModel;
+
+/**
+ * Created by skwmium on 15.07.16.
+ */
+public interface OnItemCLickListener {
+    void onItemClick(BaseViewModel viewModel);
+}

--- a/app/src/main/java/com/softdesign/devintensive/ui/fragments/BaseFragment.java
+++ b/app/src/main/java/com/softdesign/devintensive/ui/fragments/BaseFragment.java
@@ -5,13 +5,13 @@ import android.content.Context;
 import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.IdRes;
-import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.StringRes;
 import android.view.View;
 
 import com.softdesign.devintensive.presenter.BasePresenter;
 import com.softdesign.devintensive.ui.activities.BaseActivity;
+import com.softdesign.devintensive.utils.L;
 
 import butterknife.ButterKnife;
 import butterknife.Unbinder;
@@ -55,7 +55,7 @@ public abstract class BaseFragment extends Fragment {
             return getActivity();
     }
 
-    @NonNull
+    @Nullable
     protected BaseActivity getBaseActivity() {
         return (BaseActivity) getActivity();
     }
@@ -64,14 +64,21 @@ public abstract class BaseFragment extends Fragment {
     protected abstract BasePresenter getPresenter();
 
     public void showMessage(@StringRes int res) {
-        getBaseActivity().showSnackbar(res);
+        BaseActivity baseActivity = getBaseActivity();
+        if (baseActivity != null)
+            baseActivity.showSnackbar(res);
     }
 
     public void showProgress() {
-        getBaseActivity().showProgress();
+        BaseActivity baseActivity = getBaseActivity();
+        if (baseActivity != null)
+            getBaseActivity().showProgress();
     }
 
     public void hideProgress() {
-        getBaseActivity().hideProgress();
+        L.e("hide progress ", this);
+        BaseActivity baseActivity = getBaseActivity();
+        if (baseActivity != null)
+            getBaseActivity().hideProgress();
     }
 }

--- a/app/src/main/java/com/softdesign/devintensive/ui/fragments/FragmentProfileList.java
+++ b/app/src/main/java/com/softdesign/devintensive/ui/fragments/FragmentProfileList.java
@@ -1,0 +1,80 @@
+package com.softdesign.devintensive.ui.fragments;
+
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import com.softdesign.devintensive.R;
+import com.softdesign.devintensive.di.DaggerComponentProfileList;
+import com.softdesign.devintensive.di.ModuleProfileList;
+import com.softdesign.devintensive.presenter.BasePresenter;
+import com.softdesign.devintensive.presenter.PresenterProfileList;
+import com.softdesign.devintensive.ui.adapters.AdapterProfileList;
+import com.softdesign.devintensive.ui.viewmodel.ProfileViewModel;
+import com.softdesign.devintensive.view.ViewProfileList;
+
+import java.util.List;
+
+import javax.inject.Inject;
+
+import butterknife.BindView;
+
+/**
+ * Created by skwmium on 14.07.16.
+ */
+public class FragmentProfileList extends BaseFragment implements ViewProfileList {
+    @BindView(R.id.recycler)
+    RecyclerView recyclerView;
+
+    @Inject
+    PresenterProfileList mPresenter;
+    private AdapterProfileList mAdapterProfileList;
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        DaggerComponentProfileList
+                .builder()
+                .moduleProfileList(new ModuleProfileList(this))
+                .build()
+                .inject(this);
+    }
+
+    @Nullable
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        return inflater.inflate(R.layout.fragment_profile_list, container, false);
+    }
+
+    @Override
+    public void onViewCreated(View view, Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+        recyclerView.setLayoutManager(new LinearLayoutManager(getContext()));
+        mAdapterProfileList = new AdapterProfileList();
+        recyclerView.setAdapter(mAdapterProfileList);
+
+        mPresenter.onViewCreated(savedInstanceState);
+    }
+
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        mPresenter.onSaveInstanceState(outState);
+    }
+
+    @Nullable
+    @Override
+    protected BasePresenter getPresenter() {
+        return mPresenter;
+    }
+
+    @Override
+    public void showProfileList(List<ProfileViewModel> profileViewModels) {
+        mAdapterProfileList.setItems(profileViewModels);
+    }
+}

--- a/app/src/main/java/com/softdesign/devintensive/ui/view/AspectRatioImageView.java
+++ b/app/src/main/java/com/softdesign/devintensive/ui/view/AspectRatioImageView.java
@@ -1,0 +1,63 @@
+package com.softdesign.devintensive.ui.view;
+
+import android.content.Context;
+import android.content.res.TypedArray;
+import android.util.AttributeSet;
+import android.widget.ImageView;
+
+import com.softdesign.devintensive.R;
+
+/**
+ * Created by skwmium on 14.07.16.
+ */
+public class AspectRatioImageView extends ImageView {
+    private static final float ASPECT_RATIO_16_9 = 1.78f;
+    private static final float ASPECT_RATIO_4_3 = 1.33f;
+    private static final float ASPECT_RATIO_1_1 = 1f;
+
+    private float mAspectRatio;
+
+    public AspectRatioImageView(Context context) {
+        super(context);
+        init(context, null);
+    }
+
+    public AspectRatioImageView(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        init(context, attrs);
+    }
+
+    private void init(Context context, AttributeSet attrs) {
+        int flag = 0;
+        if (context != null) {
+            TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.AspectRatioImageView);
+            flag = a.getInt(R.styleable.AspectRatioImageView_aspect_ratio, 0);
+            a.recycle();
+        }
+        mAspectRatio = flagToFloat(flag);
+    }
+
+    @Override
+    protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+        super.onMeasure(widthMeasureSpec, heightMeasureSpec);
+
+        int newWidth = getMeasuredWidth();
+        int newHeight = (int) (newWidth / mAspectRatio);
+        setMeasuredDimension(newWidth, newHeight);
+    }
+
+
+    //magic numbers! Check 'aspect_ratio' attribute!
+    private float flagToFloat(int flag) {
+        switch (flag) {
+            case 0:
+                return ASPECT_RATIO_16_9;
+            case 1:
+                return ASPECT_RATIO_4_3;
+            case 2:
+                return ASPECT_RATIO_1_1;
+            default:
+                return ASPECT_RATIO_16_9;
+        }
+    }
+}

--- a/app/src/main/java/com/softdesign/devintensive/ui/view/DividerView.java
+++ b/app/src/main/java/com/softdesign/devintensive/ui/view/DividerView.java
@@ -1,0 +1,33 @@
+package com.softdesign.devintensive.ui.view;
+
+import android.content.Context;
+import android.content.res.TypedArray;
+import android.util.AttributeSet;
+import android.view.View;
+
+import com.softdesign.devintensive.R;
+
+/**
+ * Created by skwmium on 15.07.16.
+ */
+public class DividerView extends View {
+    public DividerView(Context context) {
+        super(context);
+        init(context, null);
+    }
+
+    public DividerView(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        init(context, attrs);
+    }
+
+    private void init(Context context, AttributeSet attrs) {
+        int resourceId = android.R.color.transparent;
+        if (attrs != null) {
+            TypedArray typedArray = context.obtainStyledAttributes(attrs, R.styleable.DividerView);
+            resourceId = typedArray.getResourceId(R.styleable.DividerView_dividerColor, resourceId);
+            typedArray.recycle();
+        }
+        setBackgroundResource(resourceId);
+    }
+}

--- a/app/src/main/java/com/softdesign/devintensive/ui/view/ProfilePublicInfoView.java
+++ b/app/src/main/java/com/softdesign/devintensive/ui/view/ProfilePublicInfoView.java
@@ -1,0 +1,38 @@
+package com.softdesign.devintensive.ui.view;
+
+import android.content.Context;
+import android.databinding.BindingAdapter;
+import android.databinding.DataBindingUtil;
+import android.util.AttributeSet;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.FrameLayout;
+
+import com.softdesign.devintensive.databinding.ProfileSubheaderBinding;
+import com.softdesign.devintensive.ui.viewmodel.ProfileViewModel;
+
+/**
+ * Created by skwmium on 14.07.16.
+ */
+public class ProfilePublicInfoView extends FrameLayout {
+
+    public ProfilePublicInfoView(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        init(context, attrs);
+    }
+
+    private void init(Context context, AttributeSet attrs) {
+        LayoutInflater inflater = LayoutInflater.from(context);
+        ProfileSubheaderBinding.inflate(inflater, this, true);
+    }
+
+    @BindingAdapter({"bind:profile"})
+    public static void setVariable(ProfilePublicInfoView view, ProfileViewModel model) {
+        if (view.getChildCount() == 0) {
+            return;
+        }
+        View boundView = view.getChildAt(0);
+        ProfileSubheaderBinding binding = DataBindingUtil.getBinding(boundView);
+        binding.setProfile(model);
+    }
+}

--- a/app/src/main/java/com/softdesign/devintensive/ui/viewmodel/BaseViewModel.java
+++ b/app/src/main/java/com/softdesign/devintensive/ui/viewmodel/BaseViewModel.java
@@ -1,12 +1,10 @@
 package com.softdesign.devintensive.ui.viewmodel;
 
 import android.databinding.BaseObservable;
-
-import java.io.Serializable;
+import android.os.Parcelable;
 
 /**
  * Created by skwmium on 29.06.16.
  */
-//TODO use Parcelable instead Serializable
-public abstract class BaseViewModel extends BaseObservable implements Serializable {
+public abstract class BaseViewModel extends BaseObservable implements Parcelable {
 }

--- a/app/src/main/java/com/softdesign/devintensive/ui/viewmodel/EditableModel.java
+++ b/app/src/main/java/com/softdesign/devintensive/ui/viewmodel/EditableModel.java
@@ -5,4 +5,6 @@ package com.softdesign.devintensive.ui.viewmodel;
  */
 public interface EditableModel {
     boolean isEditable();
+
+    boolean isCanBeEditable();
 }

--- a/app/src/main/java/com/softdesign/devintensive/ui/viewmodel/ProfileViewModel.java
+++ b/app/src/main/java/com/softdesign/devintensive/ui/viewmodel/ProfileViewModel.java
@@ -95,7 +95,8 @@ public class ProfileViewModel extends BaseViewModel implements EditableModel {
         Picasso.with(view.getContext())
                 .load(url)
                 .placeholder(placeholder)
-                .resize(view.getWidth(), view.getHeight())
+                .resize(Utils.getFullScreenWidthRatio16().x,
+                        Utils.getFullScreenWidthRatio16().y)
                 .into(view);
     }
 

--- a/app/src/main/java/com/softdesign/devintensive/ui/viewmodel/ProfileViewModel.java
+++ b/app/src/main/java/com/softdesign/devintensive/ui/viewmodel/ProfileViewModel.java
@@ -3,10 +3,13 @@ package com.softdesign.devintensive.ui.viewmodel;
 import android.databinding.Bindable;
 import android.databinding.BindingAdapter;
 import android.graphics.drawable.Drawable;
+import android.os.Parcel;
+import android.os.Parcelable;
 import android.support.annotation.Nullable;
 import android.widget.ImageView;
 
 import com.softdesign.devintensive.BR;
+import com.softdesign.devintensive.utils.Utils;
 import com.squareup.picasso.Picasso;
 
 /**
@@ -30,8 +33,62 @@ public class ProfileViewModel extends BaseViewModel implements EditableModel {
     private String mPhotoUrl;
     private boolean mIsEditable;
 
+    public ProfileViewModel() {
+    }
+
+    protected ProfileViewModel(Parcel in) {
+        mName = in.readString();
+        mRating = in.readString();
+        mLinesCount = in.readString();
+        mProjectCount = in.readString();
+        mMobilePhoneNumber = in.readString();
+        mEmail = in.readString();
+        mVkProfile = in.readString();
+        mRepository = in.readString();
+        mAbout = in.readString();
+        mAvatarUrl = in.readString();
+        mPhotoUrl = in.readString();
+        mIsEditable = in.readByte() != 0x00;
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeString(mName);
+        dest.writeString(mRating);
+        dest.writeString(mLinesCount);
+        dest.writeString(mProjectCount);
+        dest.writeString(mMobilePhoneNumber);
+        dest.writeString(mEmail);
+        dest.writeString(mVkProfile);
+        dest.writeString(mRepository);
+        dest.writeString(mAbout);
+        dest.writeString(mAvatarUrl);
+        dest.writeString(mPhotoUrl);
+        dest.writeByte((byte) (mIsEditable ? 0x01 : 0x00));
+    }
+
+    @SuppressWarnings("unused")
+    public static final Parcelable.Creator<ProfileViewModel> CREATOR = new Parcelable.Creator<ProfileViewModel>() {
+        @Override
+        public ProfileViewModel createFromParcel(Parcel in) {
+            return new ProfileViewModel(in);
+        }
+
+        @Override
+        public ProfileViewModel[] newArray(int size) {
+            return new ProfileViewModel[size];
+        }
+    };
+
     @BindingAdapter({"bind:imageUrl", "bind:placeholder"})
     public static void loadImage(ImageView view, String url, Drawable placeholder) {
+        if (Utils.isNullOrEmpty(url))
+            return;
         Picasso.with(view.getContext())
                 .load(url)
                 .placeholder(placeholder)

--- a/app/src/main/java/com/softdesign/devintensive/ui/viewmodel/ProfileViewModel.java
+++ b/app/src/main/java/com/softdesign/devintensive/ui/viewmodel/ProfileViewModel.java
@@ -95,7 +95,7 @@ public class ProfileViewModel extends BaseViewModel implements EditableModel {
         Picasso.with(view.getContext())
                 .load(url)
                 .placeholder(placeholder)
-                .fit()
+                .resize(view.getWidth(), view.getHeight())
                 .into(view);
     }
 

--- a/app/src/main/java/com/softdesign/devintensive/ui/viewmodel/ProfileViewModel.java
+++ b/app/src/main/java/com/softdesign/devintensive/ui/viewmodel/ProfileViewModel.java
@@ -32,6 +32,7 @@ public class ProfileViewModel extends BaseViewModel implements EditableModel {
     private String mAvatarUrl;
     private String mPhotoUrl;
     private boolean mIsEditable;
+    private boolean mIsCanBeEditable;
 
     public ProfileViewModel() {
     }
@@ -49,6 +50,7 @@ public class ProfileViewModel extends BaseViewModel implements EditableModel {
         mAvatarUrl = in.readString();
         mPhotoUrl = in.readString();
         mIsEditable = in.readByte() != 0x00;
+        mIsCanBeEditable = in.readByte() != 0x00;
     }
 
     @Override
@@ -70,6 +72,7 @@ public class ProfileViewModel extends BaseViewModel implements EditableModel {
         dest.writeString(mAvatarUrl);
         dest.writeString(mPhotoUrl);
         dest.writeByte((byte) (mIsEditable ? 0x01 : 0x00));
+        dest.writeByte((byte) (mIsCanBeEditable ? 0x01 : 0x00));
     }
 
     @SuppressWarnings("unused")
@@ -205,6 +208,12 @@ public class ProfileViewModel extends BaseViewModel implements EditableModel {
         return mIsEditable;
     }
 
+    @Override
+    @Bindable
+    public boolean isCanBeEditable() {
+        return mIsCanBeEditable;
+    }
+
     // ---------- SETTERS ----------
 
 
@@ -266,5 +275,10 @@ public class ProfileViewModel extends BaseViewModel implements EditableModel {
     public void setEditable(boolean editable) {
         mIsEditable = editable;
         notifyPropertyChanged(BR.editable);
+    }
+
+    public void setCanBeEditable(boolean canBeEditable) {
+        mIsCanBeEditable = canBeEditable;
+        notifyPropertyChanged(BR.canBeEditable);
     }
 }

--- a/app/src/main/java/com/softdesign/devintensive/utils/Const.java
+++ b/app/src/main/java/com/softdesign/devintensive/utils/Const.java
@@ -16,6 +16,7 @@ public final class Const {
 
     // ---------- KEYS ----------
     public static final String KEY_PROFILE = "_key_profile";
+    public static final String KEY_PROFILE_LIST = "_key_profile_list";
 
 
     // ---------- REQUESTS ----------

--- a/app/src/main/java/com/softdesign/devintensive/utils/Utils.java
+++ b/app/src/main/java/com/softdesign/devintensive/utils/Utils.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.res.Resources;
+import android.graphics.Point;
 import android.net.Uri;
 import android.os.Environment;
 import android.provider.MediaStore;
@@ -15,6 +16,8 @@ import android.support.v4.content.ContextCompat;
 import android.support.v4.content.FileProvider;
 import android.util.DisplayMetrics;
 import android.util.TypedValue;
+import android.view.Display;
+import android.view.WindowManager;
 
 import com.softdesign.devintensive.common.App;
 
@@ -26,6 +29,8 @@ import java.util.Date;
  * Created by skwmium on 08.07.16.
  */
 public class Utils {
+    @Nullable
+    static Point sFullScreenWidthRatio16;
 
     // ---------- INTENTS ----------
     public static void dialPhoneNumber(@NonNull Context context, @Nullable String phoneNumber) {
@@ -129,6 +134,18 @@ public class Utils {
             return TypedValue.complexToDimensionPixelSize(typedValue.data, displayMetrics);
         }
         return 0;
+    }
+
+    public static Point getFullScreenWidthRatio16() {
+        if (sFullScreenWidthRatio16 == null) {
+            WindowManager wm = (WindowManager) App.getInst().getSystemService(Context.WINDOW_SERVICE);
+            Display display = wm.getDefaultDisplay();
+            Point size = new Point();
+            display.getSize(size);
+
+            sFullScreenWidthRatio16 = new Point(size.x, (int) (size.x / 1.78));
+        }
+        return sFullScreenWidthRatio16;
     }
 
     public static int lerp(int start, int end, float friction) {

--- a/app/src/main/java/com/softdesign/devintensive/view/ViewProfileList.java
+++ b/app/src/main/java/com/softdesign/devintensive/view/ViewProfileList.java
@@ -1,0 +1,12 @@
+package com.softdesign.devintensive.view;
+
+import com.softdesign.devintensive.ui.viewmodel.ProfileViewModel;
+
+import java.util.List;
+
+/**
+ * Created by skwmium on 14.07.16.
+ */
+public interface ViewProfileList extends View {
+    void showProfileList(List<ProfileViewModel> profileViewModels);
+}

--- a/app/src/main/res/drawable/ic_search_24dp.xml
+++ b/app/src/main/res/drawable/ic_search_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportHeight="24.0"
+        android:viewportWidth="24.0">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M15.5,14h-0.79l-0.28,-0.27C15.41,12.59 16,11.11 16,9.5 16,5.91 13.09,3 9.5,3S3,5.91 3,9.5 5.91,16 9.5,16c1.61,0 3.09,-0.59 4.23,-1.57l0.27,0.28v0.79l5,4.99L20.49,19l-4.99,-5zM9.5,14C7.01,14 5,11.99 5,9.5S7.01,5 9.5,5 14,7.01 14,9.5 11.99,14 9.5,14z"/>
+</vector>

--- a/app/src/main/res/layout/activity_profile_list.xml
+++ b/app/src/main/res/layout/activity_profile_list.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.v4.widget.DrawerLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/drawer_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
+    tools:context=".ui.activities.ActivityProfile"
+    tools:openDrawer="start">
+
+    <include
+        android:id="@+id/app_bar_profile_list"
+        layout="@layout/app_bar_profile_list"/>
+
+    <android.support.design.widget.NavigationView
+        android:id="@+id/nav_view"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:layout_gravity="start"
+        android:fitsSystemWindows="true"
+        app:headerLayout="@layout/nav_header_main"
+        app:menu="@menu/activity_profile_drawer"/>
+
+</android.support.v4.widget.DrawerLayout>

--- a/app/src/main/res/layout/app_bar_profile.xml
+++ b/app/src/main/res/layout/app_bar_profile.xml
@@ -33,7 +33,8 @@
                 app:contentScrim="@color/profile_subheader_bg"
                 app:expandedTitleMarginEnd="64dp"
                 app:expandedTitleMarginStart="48dp"
-                app:layout_scrollFlags="scroll|exitUntilCollapsed">
+                app:layout_scrollFlags="scroll|exitUntilCollapsed"
+                app:title="@{profile.name}">
 
                 <FrameLayout
                     android:layout_width="match_parent"
@@ -115,6 +116,7 @@
             android:layout_height="wrap_content"
             android:layout_margin="@dimen/activity_horizontal_margin"
             android:src="@{profile.editable ? @drawable/ic_done_24dp : @drawable/ic_edit_24dp}"
+            android:visibility="@{profile.canBeEditable ? View.VISIBLE : View.GONE}"
             app:layout_anchor="@id/app_bar"
             app:layout_anchorGravity="bottom|right|end"/>
     </android.support.design.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/app_bar_profile.xml
+++ b/app/src/main/res/layout/app_bar_profile.xml
@@ -102,8 +102,10 @@
             app:behavior_min_height="@dimen/profile_subheader_height_min"
             app:layout_behavior=".ui.view.behaviors.ProfileSubheaderBehavior">
 
-            <include
-                layout="@layout/profile_subheader"
+            <com.softdesign.devintensive.ui.view.ProfilePublicInfoView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:theme="@style/profile_public_info_dark"
                 bind:profile="@{profile}"/>
         </LinearLayout>
 

--- a/app/src/main/res/layout/app_bar_profile_list.xml
+++ b/app/src/main/res/layout/app_bar_profile_list.xml
@@ -24,5 +24,6 @@
         android:id="@+id/recycler"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:orientation="vertical"/>
+        android:orientation="vertical"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior"/>
 </android.support.design.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/app_bar_profile_list.xml
+++ b/app/src/main/res/layout/app_bar_profile_list.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.design.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@android:color/background_light">
+
+    <android.support.design.widget.AppBarLayout
+        android:id="@+id/app_bar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:theme="@style/AppTheme.AppBarOverlay">
+
+        <android.support.v7.widget.Toolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            app:layout_collapseMode="pin"
+            app:popupTheme="@style/ThemeOverlay.AppCompat.Light"/>
+    </android.support.design.widget.AppBarLayout>
+
+    <android.support.v7.widget.RecyclerView
+        android:id="@+id/recycler"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"/>
+</android.support.design.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/content_profile.xml
+++ b/app/src/main/res/layout/content_profile.xml
@@ -3,6 +3,8 @@
 
     <data>
 
+        <import type="android.view.View"/>
+
         <variable
             name="profile"
             type="com.softdesign.devintensive.ui.viewmodel.ProfileViewModel"/>
@@ -15,7 +17,9 @@
 
 
         <!--mobile-->
-        <LinearLayout style="@style/profile_item">
+        <LinearLayout
+            style="@style/profile_item"
+            android:visibility="@{profile.canBeEditable ? View.VISIBLE : View.GONE}">
 
             <ImageView
                 style="@style/profile_item_icon"
@@ -39,11 +43,15 @@
         </LinearLayout>
 
 
-        <View style="@style/profile_item_divider"/>
+        <View
+            style="@style/profile_item_divider"
+            android:visibility="@{profile.canBeEditable ? View.VISIBLE : View.GONE}"/>
 
 
         <!--email-->
-        <LinearLayout style="@style/profile_item">
+        <LinearLayout
+            style="@style/profile_item"
+            android:visibility="@{profile.canBeEditable ? View.VISIBLE : View.GONE}">
 
             <ImageView
                 style="@style/profile_item_icon"
@@ -71,11 +79,15 @@
         </LinearLayout>
 
 
-        <View style="@style/profile_item_divider"/>
+        <View
+            style="@style/profile_item_divider"
+            android:visibility="@{profile.canBeEditable ? View.VISIBLE : View.GONE}"/>
 
 
         <!--vkontakte-->
-        <LinearLayout style="@style/profile_item">
+        <LinearLayout
+            style="@style/profile_item"
+            android:visibility="@{profile.canBeEditable ? View.VISIBLE : View.GONE}">
 
             <ImageView
                 style="@style/profile_item_icon"
@@ -99,7 +111,9 @@
         </LinearLayout>
 
 
-        <View style="@style/profile_item_divider"/>
+        <View
+            style="@style/profile_item_divider"
+            android:visibility="@{profile.canBeEditable ? View.VISIBLE : View.GONE}"/>
 
 
         <!--repo-->

--- a/app/src/main/res/layout/fragment_profile_list.xml
+++ b/app/src/main/res/layout/fragment_profile_list.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.v7.widget.RecyclerView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/recycler"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"/>

--- a/app/src/main/res/layout/fragment_profile_list.xml
+++ b/app/src/main/res/layout/fragment_profile_list.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<android.support.v7.widget.RecyclerView
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/recycler"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical"/>

--- a/app/src/main/res/layout/item_list_profile.xml
+++ b/app/src/main/res/layout/item_list_profile.xml
@@ -73,6 +73,7 @@
                 android:background="@color/profile_item_divider"/>
 
             <Button
+                android:id="@+id/button_open"
                 style="@style/profile_list_item_button"
                 android:text="@string/profile_list_open_item"/>
         </LinearLayout>

--- a/app/src/main/res/layout/item_list_profile.xml
+++ b/app/src/main/res/layout/item_list_profile.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        xmlns:bind="http://schemas.android.com/apk/res-auto">
+
+    <data>
+
+        <import type="android.view.View"/>
+
+        <variable
+            name="profile"
+            type="com.softdesign.devintensive.ui.viewmodel.ProfileViewModel"/>
+    </data>
+
+    <android.support.v7.widget.CardView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="@dimen/spacing_small_8"
+        android:layout_marginRight="@dimen/spacing_small_8"
+        android:layout_marginTop="@dimen/spacing_small_8"
+        app:cardBackgroundColor="@android:color/white"
+        app:cardCornerRadius="2dp">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <FrameLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <com.softdesign.devintensive.ui.view.AspectRatioImageView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:aspect_ratio="ratio_16x9"
+                    app:imageUrl="@{profile.photoUrl}"
+                    app:placeholder="@{@drawable/bg_user}"/>
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="bottom"
+                    android:paddingBottom="@dimen/spacing_medial_24"
+                    android:paddingLeft="@dimen/spacing_normal_16"
+                    android:paddingRight="@dimen/spacing_normal_16"
+                    android:text="@{profile.name}"
+                    android:textColor="@android:color/white"
+                    android:textSize="@dimen/font_larger_24"/>
+            </FrameLayout>
+
+            <com.softdesign.devintensive.ui.view.ProfilePublicInfoView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/spacing_small_8"
+                android:layout_marginTop="@dimen/spacing_small_8"
+                android:theme="@style/profile_public_info_lite"
+                bind:profile="@{profile}"/>
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/spacing_normal_16"
+                android:layout_marginLeft="@dimen/spacing_normal_16"
+                android:layout_marginRight="@dimen/spacing_normal_16"
+                android:maxLines="3"
+                android:text="@{profile.about}"
+                android:visibility="@{profile.about.empty ? View.GONE : View.VISIBLE}"/>
+
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="1px"
+                android:background="@color/profile_item_divider"/>
+
+            <Button
+                style="@style/profile_list_item_button"
+                android:text="@string/profile_list_open_item"/>
+        </LinearLayout>
+    </android.support.v7.widget.CardView>
+</layout>

--- a/app/src/main/res/layout/profile_subheader.xml
+++ b/app/src/main/res/layout/profile_subheader.xml
@@ -8,7 +8,10 @@
             type="com.softdesign.devintensive.ui.viewmodel.ProfileViewModel"/>
     </data>
 
-    <merge>
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/profile_subheader_height_min"
+        android:orientation="horizontal">
 
         <LinearLayout
             style="@style/profile_subheader_item"
@@ -23,7 +26,8 @@
                 android:text="@string/profile_label_rating"/>
         </LinearLayout>
 
-        <View style="@style/profile_subheader_divider"/>
+        <com.softdesign.devintensive.ui.view.DividerView
+            style="@style/profile_subheader_divider"/>
 
         <LinearLayout
             style="@style/profile_subheader_item"
@@ -38,7 +42,8 @@
                 android:text="@string/profile_label_lines_count"/>
         </LinearLayout>
 
-        <View style="@style/profile_subheader_divider"/>
+        <com.softdesign.devintensive.ui.view.DividerView
+            style="@style/profile_subheader_divider"/>
 
         <LinearLayout
             style="@style/profile_subheader_item"
@@ -52,5 +57,5 @@
                 style="@style/profile_subheader_text.subtext"
                 android:text="@string/profile_label_projects_count"/>
         </LinearLayout>
-    </merge>
+    </LinearLayout>
 </layout>

--- a/app/src/main/res/menu/toolbar_profile_list.xml
+++ b/app/src/main/res/menu/toolbar_profile_list.xml
@@ -1,0 +1,11 @@
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+      xmlns:app="http://schemas.android.com/apk/res-auto"
+      xmlns:tools="http://schemas.android.com/tools"
+      tools:context=".ui.activities.ActivityProfileList">
+    <item
+        android:id="@+id/nav_search"
+        android:icon="@android:drawable/ic_menu_search"
+        android:title=""
+        app:actionViewClass="android.support.v7.widget.SearchView"
+        app:showAsAction="collapseActionView|ifRoom"/>
+</menu>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -8,4 +8,17 @@
     <declare-styleable name="ProfileSubheaderBehavior">
         <attr name="behavior_min_height" format="dimension"/>
     </declare-styleable>
+
+
+    <declare-styleable name="AspectRatioImageView">
+        <attr name="aspect_ratio" format="enum">
+            <enum name="ratio_16x9" value="0"/>
+            <enum name="ratio_4x3" value="1"/>
+            <enum name="ratio_1x1" value="2"/>
+        </attr>
+    </declare-styleable>
+
+    <declare-styleable name="DividerView">
+        <attr name="dividerColor" format="reference"/>
+    </declare-styleable>
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -23,6 +23,7 @@
     <dimen name="font_normal_15">15sp</dimen>
     <dimen name="font_large_18">18sp</dimen>
     <dimen name="font_larger_22">22sp</dimen>
+    <dimen name="font_larger_24">24sp</dimen>
 
     <!--nav drawer-->
     <dimen name="drawer_header_height">172dp</dimen>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,7 +3,7 @@
 
     <!--nav drawer-->
     <string name="nav_item_profile">Профиль</string>
-    <string name="nav_item_contacts">Контакты</string>
+    <string name="nav_item_contacts">Команда</string>
 
     <!--auth screen-->
     <string name="auth_screen_title">Войти</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -39,6 +39,9 @@
         <item>Отмена</item>
     </string-array>
 
+    <!--profile list-->
+    <string name="profile_list_open_item">Просмотр</string>
+
     <!--error-->
     <string name="error_loading_data">Ошибка во время загрузки данных</string>
     <string name="error_indefinite">Произошла ошшибка, повторите действие позже</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -47,7 +47,6 @@
     </style>
 
     <style name="profile_subheader_divider">
-        <item name="android:background">@color/profile_subheader_divider</item>
         <item name="android:layout_width">1dp</item>
         <item name="android:layout_height">@dimen/profile_subheader_height_min</item>
     </style>
@@ -56,7 +55,6 @@
         <item name="android:layout_width">wrap_content</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:textSize">@dimen/font_larger_22</item>
-        <item name="android:textColor">@android:color/primary_text_dark</item>
         <item name="android:fontFamily">sans-serif</item>
     </style>
 
@@ -111,6 +109,28 @@
     </style>
 
 
+    <!--profile public info-->
+    <style name="profile_public_info_dark" parent="AppTheme">
+        <item name="android:textColor">@android:color/primary_text_dark</item>
+        <item name="dividerColor">@color/profile_subheader_divider</item>
+    </style>
+
+    <style name="profile_public_info_lite" parent="AppTheme">
+        <item name="android:textColor">@android:color/primary_text_light</item>
+        <item name="android:background">@android:color/white</item>
+        <item name="dividerColor">@android:color/transparent</item>
+    </style>
+
+    <!--profile list-->
+    <style name="profile_list_item_button" parent="Widget.AppCompat.Button.Borderless">
+        <item name="android:layout_width">wrap_content</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:layout_marginTop">@dimen/spacing_small_8</item>
+        <item name="android:paddingLeft">@dimen/spacing_normal_16</item>
+        <item name="android:paddingRight">@dimen/spacing_normal_16</item>
+        <item name="android:textColor">@color/color_accent</item>
+    </style>
+
     <!--auth screen-->
     <style name="auth_button_login">
         <item name="android:layout_width">match_parent</item>
@@ -148,5 +168,4 @@
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">wrap_content</item>
     </style>
-
 </resources>


### PR DESCRIPTION
Оцениваю данный пулл реквест на 1.

**Просмотр данных пользователя** - не делал новую активити. Просмотр/редактирование своего профиля и просмотр любого чужого профиля происходит в той же активити. При маппинге проверяется id пользователя, и если это мы, то показываем все поля, иначе убираем часть полей и кнопку редактирования.

**Список пользователей, Parcelable** - сделано

**Поиск пользователя по списку** - сделано, не используется Filter

**Ресайз изображений в списке при помощи Picasso** - сделано, но практически не помогло)

**Также** чтобы не дублировать код, создал кастомные вьюхи. ProfilePublicInfoView делает только одно - берет лейаут и биндит в него вьюмодель. Кастомный разделитель DividerView нужен чтобы можно было установив тему на весь блок profile info и перекрасить или убрать разделители. 

Потратил много времени чтобы переделать проект на работу с фрагментами внутри одной активити. Откатился, тк не пришел к архитектуре, которая мне бы понравилась, а надо было уже дз начинать делать. Буду думать еще. Из-за заминки с этим рефакторингом не стал пока прикручивать ретеин фрагмент, сохраняю данные в бандл. И из-за этого из дравера сейчас пропало имя и аватарка. После рефакторинга верну.
Не успел сделать отображение массива репозиториев при просмотре профиля.
